### PR TITLE
Dpop flow

### DIFF
--- a/.rspec_status
+++ b/.rspec_status
@@ -1,17 +1,17 @@
 example_id                                          | status | run_time        |
 --------------------------------------------------- | ------ | --------------- |
-./spec/atproto_client/client_spec.rb[1:1:1]         | passed | 0.00049 seconds |
-./spec/atproto_client/client_spec.rb[1:1:2]         | passed | 0.00351 seconds |
-./spec/atproto_client/client_spec.rb[1:2:1]         | passed | 0.00052 seconds |
-./spec/atproto_client/client_spec.rb[1:2:2:1]       | passed | 0.00063 seconds |
-./spec/atproto_client/client_spec.rb[1:2:2:2:1]     | passed | 0.00118 seconds |
-./spec/atproto_client/client_spec.rb[1:3:1]         | passed | 0.00092 seconds |
-./spec/atproto_client/client_spec.rb[1:3:2:1]       | passed | 0.00081 seconds |
+./spec/atproto_client/client_spec.rb[1:1:1]         | passed | 0.00042 seconds |
+./spec/atproto_client/client_spec.rb[1:1:2]         | passed | 0.00379 seconds |
+./spec/atproto_client/client_spec.rb[1:2:1]         | passed | 0.00058 seconds |
+./spec/atproto_client/client_spec.rb[1:2:2:1]       | passed | 0.0007 seconds  |
+./spec/atproto_client/client_spec.rb[1:2:2:2:1]     | passed | 0.00128 seconds |
+./spec/atproto_client/client_spec.rb[1:3:1]         | passed | 0.00059 seconds |
+./spec/atproto_client/client_spec.rb[1:3:2:1]       | passed | 0.00266 seconds |
 ./spec/atproto_client/dpop_handler_spec.rb[1:1:1]   | passed | 0.00124 seconds |
-./spec/atproto_client/dpop_handler_spec.rb[1:1:2]   | passed | 0.0001 seconds  |
-./spec/atproto_client/dpop_handler_spec.rb[1:2:1]   | passed | 0.00077 seconds |
-./spec/atproto_client/dpop_handler_spec.rb[1:2:2]   | passed | 0.00205 seconds |
-./spec/atproto_client/dpop_handler_spec.rb[1:2:3:1] | passed | 0.00054 seconds |
-./spec/atproto_client/dpop_handler_spec.rb[1:3:1]   | passed | 0.00014 seconds |
+./spec/atproto_client/dpop_handler_spec.rb[1:1:2]   | passed | 0.00012 seconds |
+./spec/atproto_client/dpop_handler_spec.rb[1:2:1]   | passed | 0.00095 seconds |
+./spec/atproto_client/dpop_handler_spec.rb[1:2:2]   | passed | 0.00184 seconds |
+./spec/atproto_client/dpop_handler_spec.rb[1:2:3:1] | passed | 0.00055 seconds |
+./spec/atproto_client/dpop_handler_spec.rb[1:3:1]   | passed | 0.00025 seconds |
 ./spec/atproto_client/dpop_handler_spec.rb[1:4:1]   | passed | 0.00075 seconds |
-./spec/atproto_client/dpop_handler_spec.rb[1:4:2:1] | passed | 0.00088 seconds |
+./spec/atproto_client/dpop_handler_spec.rb[1:4:2:1] | passed | 0.00085 seconds |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atproto_client (0.1.0)
+    atproto_client (0.1.2)
       jwt (~> 2.7)
       openssl (~> 3.0)
 

--- a/lib/atproto_client/client.rb
+++ b/lib/atproto_client/client.rb
@@ -17,7 +17,7 @@ module AtProto
         @dpop_handler.make_request(
           uri.to_s,
           method,
-          headers: { 'Authorization' => "Bearer #{@access_token}" },
+          headers: { 'Authorization' => "DPoP #{@access_token}" },
           body: body
         )
       rescue TokenExpiredError => e

--- a/lib/atproto_client/request.rb
+++ b/lib/atproto_client/request.rb
@@ -59,11 +59,9 @@ module AtProto
 
     def handle_response(response)
       case response.code.to_i
-      when 400
+      when 400..499
         body = JSON.parse(response.body)
         response.error! if body['error'] == 'use_dpop_nonce'
-      when 401
-        body = JSON.parse(response.body)
         raise TokenExpiredError if body['error'] == 'TokenExpiredError'
 
         raise AuthError, "Unauthorized: #{body['error']}"

--- a/lib/atproto_client/version.rb
+++ b/lib/atproto_client/version.rb
@@ -1,3 +1,3 @@
 module AtProto
-  VERSION = '0.1.0'
+  VERSION = '0.1.2'
 end

--- a/spec/atproto_client/client_spec.rb
+++ b/spec/atproto_client/client_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AtProto::Client do
         .with(
           "#{url}?foo=bar",
           method,
-          headers: { 'Authorization' => "Bearer #{access_token}" },
+          headers: { 'Authorization' => "DPoP #{access_token}" },
           body: body
         )
         .and_return(double('response'))
@@ -45,7 +45,7 @@ RSpec.describe AtProto::Client do
           .with(
             url,
             method,
-            headers: { 'Authorization' => "Bearer #{access_token}" },
+            headers: { 'Authorization' => "DPoP #{access_token}" },
             body: nil
           )
           .and_raise(AtProto::TokenExpiredError)
@@ -57,7 +57,7 @@ RSpec.describe AtProto::Client do
           .with(
             url,
             method,
-            headers: { 'Authorization' => "Bearer #{access_token}" },
+            headers: { 'Authorization' => "DPoP #{access_token}" },
             body: nil
           )
           .and_return(success_response)
@@ -74,7 +74,7 @@ RSpec.describe AtProto::Client do
             .with(
               url,
               method,
-              headers: { 'Authorization' => "Bearer #{access_token}" },
+              headers: { 'Authorization' => "DPoP #{access_token}" },
               body: nil
             )
             .and_raise(AtProto::TokenExpiredError)


### PR DESCRIPTION
Realized previous version didn´t really work on protected routes.
- access token in the Authorization HTTP header starts with type DPoP instead of Bearer (so header looks like Authorization: DPoP <token>)
- we now add a ath key in the dpop key, which is the access_token in base64, and for that need DpopHandler takes a second optional argument (the access token).