### PR TITLE
Include full error message in case of AuthError

### DIFF
--- a/lib/atproto_client/request.rb
+++ b/lib/atproto_client/request.rb
@@ -64,7 +64,7 @@ module AtProto
         response.error! if body['error'] == 'use_dpop_nonce'
         raise TokenExpiredError if body['error'] == 'TokenExpiredError'
 
-        raise AuthError, "Unauthorized: #{body['error']}"
+        raise AuthError, "Unauthorized: #{body.values_at('error', 'message').compact.join(' - ')}"
       when 200..299
         JSON.parse(response.body)
       else


### PR DESCRIPTION
I was running into the following error:

```
 Unauthorized: InvalidToken (AtProto::AuthError)
```

Not very descriptive. Upon further inspection, I noticed there's a `body['message']` with additional details. However, I'm not sure it's ALWAYS included, so I took the safe route using `values_at` and `compact` to only show it, if it's present.

Now I get a more helpful error message:

```
 Unauthorized: InvalidToken - OAuth tokens are meant for PDS access only (AtProto::AuthError)
```