### PR TITLE
Use correct key for expired token error

### DIFF
--- a/lib/atproto_client/request.rb
+++ b/lib/atproto_client/request.rb
@@ -62,7 +62,7 @@ module AtProto
       when 400..499
         body = JSON.parse(response.body)
         response.error! if body['error'] == 'use_dpop_nonce'
-        raise TokenExpiredError if body['error'] == 'TokenExpiredError'
+        raise TokenExpiredError if body['error'] == 'invalid_token'
 
         raise AuthError, "Unauthorized: #{body['error']}"
       when 200..299


### PR DESCRIPTION
In my testing I only found the key "invalid_token" when using an expired token. I assume the "TokenExpiredError" key was a typo as all other keys are snake_case.