### PR TITLE
:memo: Doc: Updated examples to clarify pds url + real auth need

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ client = AtProto::Client.new(
 # Should be able to fetch collections
 client.request(
   :get,
-  "#{PDS_URL}/xrpc/#{lexicon}",
-  params:{ repo: "did:therepodid", collection: "app.bsky.feed.post"}
+  "https://boletus.us-west.host.bsky.network/xrpc/app.bsky.feed.getPostThread",
+  params: { uri: "at://did:plc:sdy3olcdgcxvy3enfgsujz43/app.bsky.feed.post/3lbr6ey544s2k"}
 )
 
 # Also gives a handful DPOP handler for any request (here an omniauth example)
@@ -46,9 +46,7 @@ response = @dpop_handler.make_request(
 )
 
 # you can then use the access_token from the response in conjunction with the same private_key
-
 ```
-
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests.


### PR DESCRIPTION
- Example shows what type of url to use (real pds url instead of entryways like bsky.social) and explicite lexicon
- Example uses an endpoint that needs authentication (feed.getPostThread instead of feed.post)