### PR TITLE
Add bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+echo "== Installing dependencies =="
+bundle install
+
+echo "== Setup complete ==" 


### PR DESCRIPTION
Adds missing `bin/setup` as referenced in the README.